### PR TITLE
BUG: Completion Date not stored in Recommendation Requests Table #1

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -218,7 +218,6 @@ public class RecommendationRequestController extends ApiController {
         recommendationRequest.setRequester(currentUser.getUser());
         recommendationRequest.setStatus("PENDING");
         recommendationRequest.setDueDate(dueDate);
-        recommendationRequest.setCompletionDate(null);
         RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(recommendationRequest);
         return savedRecommendationRequest;
     }

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -131,6 +131,7 @@ public class RecommendationRequestController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
         recommendationRequest.setStatus(incoming.getStatus());
+        recommendationRequest.setCompletionDate(LocalDateTime.now());
 
         recommendationRequestRepository.save(recommendationRequest);
 
@@ -191,7 +192,7 @@ public class RecommendationRequestController extends ApiController {
      * @param recommendationType recommendation types of request
      * @param details details of request
      * @param dueDate submission date of request
-     * @param completionDate completion date of request
+     * @param completionDate completion date of request by professor (if completed)
      * @return the save recommendationrequests (with it's id field set by the database)
      */
 
@@ -202,8 +203,7 @@ public class RecommendationRequestController extends ApiController {
             @Parameter(name = "professorId") @RequestParam Long professorId,
             @Parameter(name = "recommendationType") @RequestParam String recommendationType,
             @Parameter(name = "details") @RequestParam String details,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dueDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime completionDate)
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dueDate)
             {
         //get current date right now and set status to pending
         CurrentUser currentUser = getCurrentUser();
@@ -218,7 +218,7 @@ public class RecommendationRequestController extends ApiController {
         recommendationRequest.setRequester(currentUser.getUser());
         recommendationRequest.setStatus("PENDING");
         recommendationRequest.setDueDate(dueDate);
-        recommendationRequest.setCompletionDate(completionDate);
+        recommendationRequest.setCompletionDate(null);
         RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(recommendationRequest);
         return savedRecommendationRequest;
     }

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -139,7 +139,7 @@ public class RecommendationRequestController extends ApiController {
             recommendationRequest.setCompletionDate(null);
         }
         else {
-            throw new EntityNotFoundException(RecommendationRequest.class, id);
+            throw new IllegalArgumentException(String.format("Unknown Request Status: %s", incoming.getStatus()));
         }
 
         recommendationRequestRepository.save(recommendationRequest);

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -138,6 +138,9 @@ public class RecommendationRequestController extends ApiController {
         else if (incoming.getStatus().equals("PENDING") || incoming.getStatus().equals("ACCEPTED")) {
             recommendationRequest.setCompletionDate(null);
         }
+        else {
+            throw new EntityNotFoundException(RecommendationRequest.class, id);
+        }
 
         recommendationRequestRepository.save(recommendationRequest);
 

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -192,7 +192,6 @@ public class RecommendationRequestController extends ApiController {
      * @param recommendationType recommendation types of request
      * @param details details of request
      * @param dueDate submission date of request
-     * @param completionDate completion date of request by professor (if completed)
      * @return the save recommendationrequests (with it's id field set by the database)
      */
 

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -191,6 +191,7 @@ public class RecommendationRequestController extends ApiController {
      * @param recommendationType recommendation types of request
      * @param details details of request
      * @param dueDate submission date of request
+     * @param completionDate completion date of request
      * @return the save recommendationrequests (with it's id field set by the database)
      */
 
@@ -201,7 +202,8 @@ public class RecommendationRequestController extends ApiController {
             @Parameter(name = "professorId") @RequestParam Long professorId,
             @Parameter(name = "recommendationType") @RequestParam String recommendationType,
             @Parameter(name = "details") @RequestParam String details,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dueDate)
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dueDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime completionDate)
             {
         //get current date right now and set status to pending
         CurrentUser currentUser = getCurrentUser();
@@ -216,7 +218,7 @@ public class RecommendationRequestController extends ApiController {
         recommendationRequest.setRequester(currentUser.getUser());
         recommendationRequest.setStatus("PENDING");
         recommendationRequest.setDueDate(dueDate);
-
+        recommendationRequest.setCompletionDate(completionDate);
         RecommendationRequest savedRecommendationRequest = recommendationRequestRepository.save(recommendationRequest);
         return savedRecommendationRequest;
     }

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -131,7 +131,13 @@ public class RecommendationRequestController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
         recommendationRequest.setStatus(incoming.getStatus());
-        recommendationRequest.setCompletionDate(LocalDateTime.now());
+
+        if (incoming.getStatus().equals("COMPLETED") || incoming.getStatus().equals("DENIED")) {
+            recommendationRequest.setCompletionDate(LocalDateTime.now());
+        }
+        else if (incoming.getStatus().equals("PENDING") || incoming.getStatus().equals("ACCEPTED")) {
+            recommendationRequest.setCompletionDate(null);
+        }
 
         recommendationRequestRepository.save(recommendationRequest);
 

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -507,7 +507,7 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                     .characterEncoding("utf-8")
                     .content(requestBody)
                     .with(csrf()))
-                    .andExpect(status().isNotFound())
+                    .andExpect(status().isBadRequest())
                     .andReturn();
 
             //assert
@@ -515,8 +515,8 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
             verify(recommendationRequestRepository, times(0)).save(any(RecommendationRequest.class));
 
             Map<String, Object> json = responseToJson(response);
-            assertEquals("EntityNotFoundException", json.get("type"));
-            assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
+            assertEquals("IllegalArgumentException", json.get("type"));
+            assertEquals("Unknown Request Status: INVALID", json.get("message"));
         }
 
 }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.rec.controllers;
 
 import edu.ucsb.cs156.rec.entities.User;
+import edu.ucsb.cs156.rec.entities.RecommendationRequest;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,7 +36,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.rec.ControllerTestCase;
-import edu.ucsb.cs156.rec.entities.RecommendationRequest;
 import edu.ucsb.cs156.rec.repositories.RecommendationRequestRepository;
 import edu.ucsb.cs156.rec.testconfig.TestConfig;
 import joptsimple.internal.OptionNameMap;
@@ -48,35 +49,44 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
     @MockBean
     UserRepository userRepository;
 
+    private static User buildProfessor(String email, String googleSub, String fullName, String givenName, String familyName, Long id) {
+        return User.builder()
+                    .id(id)
+                    .email(email)
+                    .googleSub(googleSub)
+                    .fullName(fullName)
+                    .givenName(givenName)
+                    .familyName(familyName)
+                    .emailVerified(true)
+                    .professor(true)
+                    .build();
+    }
+
+    private static RecommendationRequest buildRecommendationRequest(Long id, User requester, User professor, String recommendationType, String details, String status, String dueDate, String submissionDate, String lastModifiedDate, String completionDate) {
+        return RecommendationRequest.builder()
+                    .id(id)
+                    .requester(requester)
+                    .professor(professor)
+                    .recommendationType(recommendationType)
+                    .details(details)
+                    .status(status)
+                    .dueDate(LocalDateTime.parse(dueDate))
+                    .submissionDate(LocalDateTime.parse(submissionDate))
+                    .lastModifiedDate(LocalDateTime.parse(lastModifiedDate))
+                    .completionDate(completionDate != null ? LocalDateTime.parse(completionDate) : null)
+                    .build();
+    }
+
     //User can delete their own recommendation request
     @WithMockUser(roles = { "USER" })
     @Test
     public void  user_can_delete_their_recommendation_request() throws Exception {
 
         User user = currentUserService.getCurrentUser().getUser(); 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        
         // arrange
-        RecommendationRequest recReq = RecommendationRequest.builder()
-                .id(15L)
-                .requester(user)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest recReq = buildRecommendationRequest(15L, user, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", null);
 
         when(recommendationRequestRepository.findByIdAndRequester(eq(15L), eq(user))).thenReturn(Optional.of(recReq));
 
@@ -102,29 +112,9 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         // arrange
         User user1 = currentUserService.getCurrentUser().getUser(); 
         User user2 = User.builder().id(44).build(); 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
 
-        RecommendationRequest rec1 = RecommendationRequest.builder()
-                .id(15L)
-                .requester(user1)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest rec1 = buildRecommendationRequest(15L, user1, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
                 
         when(recommendationRequestRepository.findByIdAndRequester(eq(15L),eq(user2))).thenReturn(Optional.of(rec1));
 
@@ -148,30 +138,8 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
 
         User user1 = currentUserService.getCurrentUser().getUser();
         User user2 = User.builder().id(44).build();
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-        
-
-        RecommendationRequest rec1 = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user2)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        RecommendationRequest rec1 = buildRecommendationRequest(67L, user2, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
         when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec1));
 
@@ -194,29 +162,8 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         // arrange
 
         User user2 = User.builder().id(44).build(); 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-
-        RecommendationRequest rec1 = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user2)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        RecommendationRequest rec1 = buildRecommendationRequest(67L, user2, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
         when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec1));
         // act
@@ -258,57 +205,10 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
     @Test
     public void user_logged_in_put_recommendation_request() throws Exception {
         User user1 = currentUserService.getCurrentUser().getUser(); 
-        
-        User prof1 = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-
-        RecommendationRequest rec = RecommendationRequest.builder()
-                .id(63L)
-                .requester(user1)
-                .professor(prof1)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
-
-        RecommendationRequest rec_updated = RecommendationRequest.builder()
-                .id(63L)
-                .requester(user1)
-                .professor(prof1)
-                .recommendationType("PhDprogram")
-                .details("more details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
-
-        RecommendationRequest rec_corrected = RecommendationRequest.builder()
-                .id(63L)
-                .requester(user1)
-                .professor(prof1)
-                .recommendationType("PhDprogram")
-                .details("more details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
-              
+        User prof1 = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        RecommendationRequest rec = buildRecommendationRequest(63L, user1, prof1, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
+        RecommendationRequest rec_updated = buildRecommendationRequest(63L, user1, prof1, "PhDprogram", "more details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
+        RecommendationRequest rec_corrected = buildRecommendationRequest(63L, user1, prof1, "PhDprogram", "more details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");              
         
         String requestBody = mapper.writeValueAsString(rec_updated); 
         String expectedReturn = mapper.writeValueAsString(rec_corrected); 
@@ -340,29 +240,8 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
 
         User user1 = currentUserService.getCurrentUser().getUser(); 
 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-
-        RecommendationRequest rec = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user1)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        RecommendationRequest rec = buildRecommendationRequest(67L, user1, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
         String requestBody = mapper.writeValueAsString(rec); 
         when(recommendationRequestRepository.findByIdAndRequester(eq(67L), eq(user1))).thenReturn(Optional.empty());
@@ -388,42 +267,11 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
     public void user_can_not_put_recommendation_request_for_another_user() throws Exception {
         User user1 = currentUserService.getCurrentUser().getUser(); 
         User user2 = User.builder().id(44).build(); 
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        RecommendationRequest rec = buildRecommendationRequest(67L, user2, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-        
-        RecommendationRequest rec = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user2)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
-        RecommendationRequest rec_updated = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user1)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("more details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest rec_updated = buildRecommendationRequest(67L, user1, prof, "PhDprogram", "more details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
+
         when(recommendationRequestRepository.findByIdAndRequester(eq(31L), eq(user2)))
         .thenReturn(Optional.of(rec));
 
@@ -453,42 +301,11 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
     public void prof_can_put_recommendation_request() throws Exception {
         //arrange
         User student = User.builder().id(99).build(); 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
 
-        RecommendationRequest rec = RecommendationRequest.builder()
-                .id(67L)
-                .requester(student)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest rec = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
-        RecommendationRequest rec_updated = RecommendationRequest.builder()
-                .id(67L)
-                .requester(student)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("COMPLETED")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00")) // temp date
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest rec_updated = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "COMPLETED", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
         String requestBody = mapper.writeValueAsString(rec_updated);
 
@@ -512,10 +329,8 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         RecommendationRequest savedRequest = mapper.readValue(responseString, RecommendationRequest.class);
         
-        // check that status was updated
         assertEquals("COMPLETED", savedRequest.getStatus());
         
-        // check that completion date was set
         assertNotNull(savedRequest.getCompletionDate());
         
         // check that completion date is recent
@@ -531,30 +346,9 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
     public void prof_can_not_put_recommendation_request_that_does_not_exist() throws Exception {
         //arrange
         User user2 = User.builder().id(200).build(); 
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
 
-        User prof = User.builder()
-                .id(22L)
-                .email("profA@ucsb.edu")
-                .googleSub("googleSub")
-                .fullName("Prof A")
-                .givenName("Prof")
-                .familyName("A")
-                .emailVerified(true)
-                .professor(true)
-                .build();
-
-        RecommendationRequest rec_updated = RecommendationRequest.builder()
-                .id(67L)
-                .requester(user2)
-                .professor(prof)
-                .recommendationType("PhDprogram")
-                .details("details")
-                .status("COMPLETED")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
-                .build();
+        RecommendationRequest rec_updated = buildRecommendationRequest(67L, user2, prof, "PhDprogram", "details", "COMPLETED", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
 
         String requestBody = mapper.writeValueAsString(rec_updated);
 
@@ -576,4 +370,80 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         assertEquals("EntityNotFoundException", json.get("type"));
         assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
     }
+
+        // professor can change status of recommendation request from completed back to pending, causing completion date to be set to null
+       @WithMockUser(roles = {"PROFESSOR"})
+       @Test
+       public void prof_can_put_recommendation_request_back_to_pending_completion_date_sets_to_null() throws Exception {
+        //arrange
+        User student = User.builder().id(99).build(); 
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        
+        RecommendationRequest rec = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "COMPLETED", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
+        RecommendationRequest rec_updated = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "PENDING", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", null);
+
+        String requestBody = mapper.writeValueAsString(rec_updated);
+
+        when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec));
+        when(recommendationRequestRepository.save(any(RecommendationRequest.class))).thenReturn(rec_updated);
+
+        //act
+        MvcResult response = mockMvc
+                .perform(put("/api/recommendationrequest/professor?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //assert
+        verify(recommendationRequestRepository, times(1)).findById(67L);
+        verify(recommendationRequestRepository, times(1)).save(any(RecommendationRequest.class));
+
+        String responseString = response.getResponse().getContentAsString();
+        RecommendationRequest savedRequest = mapper.readValue(responseString, RecommendationRequest.class);
+
+        // check that completion date was set to null
+        assertNull(savedRequest.getCompletionDate());
+       }
+
+        // professor can change status of recommendation request from completed back to accepted (within pending page), causing completion date to be set to null
+        @WithMockUser(roles = {"PROFESSOR"})
+       @Test
+       public void prof_can_put_recommendation_request_back_to_pending_completion_date_sets_to_null_2() throws Exception {
+        //arrange
+        User student = User.builder().id(99).build(); 
+        User prof = buildProfessor("profA@ucsb.edu", "googleSub", "Prof A", "Prof", "A", 22L);
+        
+        RecommendationRequest rec = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "COMPLETED", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00");
+
+        RecommendationRequest rec_updated = buildRecommendationRequest(67L, student, prof, "PhDprogram", "details", "ACCEPTED", "2022-01-03T00:00:00", "2022-01-03T00:00:00", "2022-01-03T00:00:00", null);
+
+        String requestBody = mapper.writeValueAsString(rec_updated);
+
+        when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec));
+        when(recommendationRequestRepository.save(any(RecommendationRequest.class))).thenReturn(rec_updated);
+
+        //act
+        MvcResult response = mockMvc
+                .perform(put("/api/recommendationrequest/professor?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //assert
+        verify(recommendationRequestRepository, times(1)).findById(67L);
+        verify(recommendationRequestRepository, times(1)).save(any(RecommendationRequest.class));
+
+        String responseString = response.getResponse().getContentAsString();
+        RecommendationRequest savedRequest = mapper.readValue(responseString, RecommendationRequest.class);
+
+        // check that completion date was set to null
+        assertNull(savedRequest.getCompletionDate());
+       }
+
 }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -475,7 +475,13 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         //act 
         MvcResult response = mockMvc
                 .perform(get("/api/recommendationrequest/admin/all")
-                         
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
         String content = response.getResponse().getContentAsString();
 
         String expectedJson1 = mapper.writeValueAsString(rec_111);
@@ -619,6 +625,10 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         //act
         MvcResult response = mockMvc
                 .perform(put("/api/recommendationrequest/professor?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -73,7 +73,6 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                 .recommendationType("PhDprogram")
                 .details("details")
                 .status("PENDING")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
@@ -485,7 +484,7 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                 .recommendationType("PhDprogram")
                 .details("details")
                 .status("COMPLETED")
-                .completionDate(null)
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00")) // temp date
                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))


### PR DESCRIPTION
### Fixed bug: Completion date now automatically fills in Recommendation Requests Table when status is updated from "PENDING" to "COMPLETED"

**Changes:**
- By default, completion date is null 
- When status updates from Pending or Accepted to Completed or Denied (ONLY), completion date is set to the current time and date
- When status updates from Completed or Denied to Pending or Accepted, completion date is set back to null 
- Helper function to build professors and recommendation requests added to Recommendation Request Controller Test file in order to reduce file size and reusability. 

**To Test:** 
1. Open https://rec-qa.dokku-14.cs.ucsb.edu and log in 
2. Open Swagger, and create a new Recommendation Request with type "Test" and Professor ID = 1.
3. Test using **PUT** method to update status from "PENDING"/"ACCEPTED" to "COMPLETED"/"DENIED" of the recommendation request as a _professor_ (or vise versa). Completion date will be set to _null_, but do not change this.
4. Check that in https://rec-qa.dokku-14.cs.ucsb.edu/requests/completed , the newly completed recommendation request appears and that the "Completion Date" is correct to when you updated the status in Swagger. 
<img width="1074" alt="Screenshot 2025-05-14 at 1 28 30 PM" src="https://github.com/user-attachments/assets/f1fd5f18-74c7-4003-9ca1-d38b867267d8" />

Closes #1 