### PR TITLE
Fixed Bug - Student should be true when new user logs in

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=false;
+  private Boolean student=true;
   @Builder.Default
   private Boolean professor=false;
 }


### PR DESCRIPTION
Closes #22 


The student role is now default when a new user logs in. This was done by changing the boolean for student in rc/main/java/edu/ucsb/cs156/rec/entities/User.java from false to true. 

![Screenshot 2025-05-15 at 12 05 42 AM](https://github.com/user-attachments/assets/6bb59d17-542a-41d3-90b6-a013dd910e74)

