### PR TITLE
FEATURE: Professor Pending Requests Page #19

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -176,6 +176,27 @@ const recommendationRequestFixtures = {
       completionDate: null,
       done: false,
     },
+    {
+      id: 9,
+      requesterEmail: "student9@ucsb.edu",
+      professorEmail: "professor1@ucsb.edu",
+      requester: {
+        fullName: "Student Nine",
+        email: "student9@ucsb.edu",
+      },
+      professor: {
+        fullName: "Professor One",
+        email: "professor1@ucsb.edu",
+      },
+      details: "Accepted request",
+      recommendationType: "Graduate School",
+      status: "ACCEPTED",
+      submissionDate: "2024-02-01T00:00:00",
+      dueDate: "2024-03-01T00:00:00",
+      lastModifiedDate: "2024-02-15T00:00:00",
+      completionDate: null,
+      done: false,
+    }
   ],
 };
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -48,14 +48,17 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   // and Completed (for ACCEPTED requests)
   const acceptCallback = async (cell) => {
     statusUpdateMutation.mutate({ cell, newStatus: "ACCEPTED" });
+    window.location.reload(); // refresh the page
   };
 
   const denyCallback = async (cell) => {
     statusUpdateMutation.mutate({ cell, newStatus: "DENIED" });
+    window.location.reload();
   };
 
   const completeCallback = async (cell) => {
     statusUpdateMutation.mutate({ cell, newStatus: "COMPLETED" });
+    window.location.reload();
   };
 
   const columns = [
@@ -156,7 +159,6 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
         "primary",
         completeCallback,
         "RecommendationRequestTable",
-        (cell) => cell.row.values.status === "ACCEPTED"
       ),
     );
   }

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -10,6 +10,10 @@ import {
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
+function formatDate(dateString) {
+  return new Date(dateString).toLocaleDateString();
+}
+
 export default function RecommendationRequestTable({ requests, currentUser }) {
   const navigate = useNavigate();
 
@@ -97,18 +101,34 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     {
       Header: "Submission Date",
       accessor: "submissionDate",
+      // turn into readable format mm/dd/yyyy
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Last Modified Date",
       accessor: "lastModifiedDate",
+      // turn into readable format mm/dd/yyyy
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Completion Date",
       accessor: "completionDate",
+      // turn into readable format mm/dd/yyyy
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Due Date",
       accessor: "dueDate",
+      // turn into readable format mm/dd/yyyy
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
   ];
 
@@ -139,31 +159,42 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   }
 
   if (hasRole(currentUser, "ROLE_PROFESSOR")) {
-    columns.push(
-      ButtonColumn(
-        "Accept",
-        "success",
-        acceptCallback,
-        "RecommendationRequestTable",
-        (cell) => cell.row.values.status === "PENDING"
-      ),
-      ButtonColumn(
-        "Deny",
-        "danger",
-        denyCallback,
-        "RecommendationRequestTable",
-        (cell) => cell.row.values.status === "PENDING"
-      ),
-      ButtonColumn(
-        "Completed",
-        "primary",
-        completeCallback,
-        "RecommendationRequestTable",
-      ),
-    );
+    // if status = PENDING, show Accept and Deny buttons
+    if ((cell) => cell.row.values.status === "PENDING") {
+      columns.push(
+        ButtonColumn(
+          "Accept",
+          "success",
+          acceptCallback,
+          "RecommendationRequestTable",
+          ),
+          ButtonColumn(
+            "Deny",
+            "danger",
+            denyCallback,
+            "RecommendationRequestTable",
+          )
+      )
+    }
+    else if ((cell) => cell.row.values.status === "ACCEPTED") {
+      columns.push(
+        ButtonColumn(
+          "Completed",
+          "primary",
+          completeCallback,
+          "RecommendationRequestTable",
+        ),
+        ButtonColumn(
+          "Deny",
+          "danger",
+          denyCallback,
+          "RecommendationRequestTable",
+        )
+      );
+    }
   }
 
-  return (
+    return (
     <OurTable
       data={requests}
       columns={columns}

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -6,7 +6,6 @@ import {
   cellToAxiosParamsDelete,
   onDeleteSuccess,
   cellToAxiosParamsUpdateStatus,
-  onStatusUpdateSuccess,
 } from "main/utils/RecommendationRequestUtils";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
@@ -33,8 +32,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
 
   // when status updates, mutate 
   const statusUpdateMutation = useBackendMutation(
-    (cell, newStatus) => cellToAxiosParamsUpdateStatus(cell, newStatus),
-    { onSuccess: onStatusUpdateSuccess },
+    cellToAxiosParamsUpdateStatus,
     [apiEndpoint],
   );
 
@@ -49,15 +47,15 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   // ADDING NEW STATTUS BUTTONS FOR PROFESSORS: Accept and Deny (for PENDING requests), 
   // and Completed (for ACCEPTED requests)
   const acceptCallback = async (cell) => {
-    statusUpdateMutation.mutate(cell, "ACCEPTED");
+    statusUpdateMutation.mutate({ cell, newStatus: "ACCEPTED" });
   };
 
   const denyCallback = async (cell) => {
-    statusUpdateMutation.mutate(cell, "DENIED");
+    statusUpdateMutation.mutate({ cell, newStatus: "DENIED" });
   };
 
   const completeCallback = async (cell) => {
-    statusUpdateMutation.mutate(cell, "COMPLETED");
+    statusUpdateMutation.mutate({ cell, newStatus: "COMPLETED" });
   };
 
   const columns = [
@@ -92,10 +90,6 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     {
       Header: "Status",
       accessor: "status",
-    },
-    {
-      Header: "Date Accepted/Denied",
-      accessor: "dateAcceptedOrDenied",
     },
     {
       Header: "Submission Date",
@@ -158,7 +152,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
         (cell) => cell.row.values.status === "PENDING"
       ),
       ButtonColumn(
-        "Check when Completed",
+        "Completed",
         "primary",
         completeCallback,
         "RecommendationRequestTable",

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -1,7 +1,7 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useBackend } from "main/utils/useBackend";
 import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
-import { hasRole, useCurrentUser } from "main/utils/currentUser";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
   const { data: currentUser } = useCurrentUser();

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -1,11 +1,41 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "main/utils/useBackend";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
-  // Stryker disable all : placeholder for future implementation
+  const { data: currentUser } = useCurrentUser();
+
+  const apiEndpoint = "/api/recommendationrequest/professor/pending";
+
+  const {
+    data: requests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    [apiEndpoint],
+    {
+      method: "GET",
+      url: apiEndpoint,
+    },
+    [],
+  );
+
+  // Filter requests for professors to only show PENDING and ACCEPTED records
+  const pendingRequests = requests?.filter(
+    (request) => request.status === "PENDING" || request.status === "ACCEPTED",
+  ) || [];
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Pending Requests page not yet implemented</h1>
+        <h1>Pending Requests</h1>
+        <div data-testid="RecommendationRequestTable">
+          <RecommendationRequestTable
+            requests={pendingRequests}
+            currentUser={currentUser}
+          />
+        </div>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -2,11 +2,14 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useBackend } from "main/utils/useBackend";
 import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
 import { useCurrentUser } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
   const { data: currentUser } = useCurrentUser();
 
-  const apiEndpoint = "/api/recommendationrequest/professor/pending";
+  const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
+    ? "/api/recommendationrequest/professor/all"
+    : "/api/recommendationrequest/requester/all";
 
   const {
     data: requests,

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -15,22 +15,19 @@ export function cellToAxiosParamsDelete(cell) {
   };
 }
 
-export function onStatusUpdateSuccess(message) {
-  console.log(message);
-  toast(message);
-}
-
 // for updating status of recommendation request
-export function cellToAxiosParamsUpdateStatus(cell, newStatus) {
-  return {
+export function cellToAxiosParamsUpdateStatus({ cell, newStatus }) {
+  const params = {
     url: "/api/recommendationrequest/professor",
     method: "PUT",
     params: {
       id: cell.row.values.id,
     },
     data: {
-      ...cell.row.original,
-      status: newStatus
+      status: newStatus,
+      details: cell.row.values.details || ""
     }
   };
+
+  return params;
 }

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -14,3 +14,23 @@ export function cellToAxiosParamsDelete(cell) {
     },
   };
 }
+
+export function onStatusUpdateSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+// for updating status of recommendation request
+export function cellToAxiosParamsUpdateStatus(cell, newStatus) {
+  return {
+    url: "/api/recommendationrequest/professor",
+    method: "PUT",
+    params: {
+      id: cell.row.values.id,
+    },
+    data: {
+      ...cell.row.original,
+      status: newStatus
+    }
+  };
+}

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -1,34 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 describe("PendingRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
+  });
+
+  test("Renders pending requests for professor", async () => {
     axiosMock
       .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
+      .reply(200, apiCurrentUserFixtures.professorUser);
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+    axiosMock
+      .onGet("/api/recommendationrequest/professor/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,7 +36,90 @@ describe("PendingRequestsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
-    await screen.findByText("Pending Requests page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "DENIED"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no pending requests", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.professorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/professor/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+  });
+
+  test("Renders empty table when no pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/requester/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -138,7 +138,7 @@ public class RecommendationRequestController extends ApiController {
         if (incoming.getStatus().equals("ACCEPTED") || incoming.getStatus().equals("DENIED")) {
             recommendationRequest.setDateAcceptedOrDenied(LocalDateTime.now());
         }
-        if (incoming.getStatus().equals("COMPLETED")) {
+        if (incoming.getStatus().equals("COMPLETED") || incoming.getStatus().equals("DENIED")) {
             recommendationRequest.setCompletionDate(LocalDateTime.now());
         }
 

--- a/src/main/java/edu/ucsb/cs156/rec/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/RecommendationRequest.java
@@ -47,6 +47,7 @@ public class RecommendationRequest {
 
   private LocalDateTime completionDate;
   private LocalDateTime dueDate;
+  private LocalDateTime dateAcceptedOrDenied;
   @CreatedDate
   private LocalDateTime submissionDate;
   @LastModifiedDate

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -89,6 +89,12 @@
                   },
                   {
                     "column": {
+                      "name": "DATE_ACCEPTED_OR_DENIED",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
                       "name": "DUE_DATE",
                       "type": "TIMESTAMP"
                     }


### PR DESCRIPTION
## Creating /requests/pending page for the Professor to see records that have the option to be accepted or denied, then completed. 
- When status = "PENDING", professor has the option to click Accept or Deny buttons.
- If accepted, accept/deny buttons go away. The record stays in the Pending Table and Status updates to "ACCEPTED". The professor then has the option to click "Completed"
- If Denied, the record moves to the Completed Table and Status updates to "DENIED".  
- If Status = Accepted and Professor clicks Completed button, record gets moved to Completed Table with status = "COMPLETED".

When a record is completed or denied, the Completion Date gets updated. When a record gets accepted or denied, the  Accepted/Denied date gets updated in the backend (but is not included in the frontend to help reduce columns for visual purposes)

**To Test:**
1. Run `mvn spring-boot:run` from root directory and `npm start` front /frontend in two separate terminals. Create a few test recommendation requests records, all in Pending status. 
<img width="1512" alt="Screenshot 2025-05-18 at 5 21 44 PM" src="https://github.com/user-attachments/assets/83f4c158-7ce1-42f7-9113-aba6f6a825e3" />

2. When accepting a request, status changes but record remains in Pending Table:
<img width="1512" alt="Screenshot 2025-05-18 at 5 22 19 PM" src="https://github.com/user-attachments/assets/05cca78b-3e0b-49e5-9233-aa95b9f8a390" />

3. When Completing a Request, status changes and record moves to Completed Table. Same with when Denying a request. 
<img width="1512" alt="Screenshot 2025-05-18 at 5 23 07 PM" src="https://github.com/user-attachments/assets/56209fa3-850d-44e5-9a0d-4b1a72872d76" />

_(dates have been since updated to display in format mm/dd/yyyy)_

Closes #19 , #23 , #15 , #8 , #14