### PR TITLE
SUBISSUE: Add Recommendation Requests Table to Professor Pending Request Page

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -176,6 +176,27 @@ const recommendationRequestFixtures = {
       completionDate: null,
       done: false,
     },
+    {
+      id: 9,
+      requesterEmail: "student9@ucsb.edu",
+      professorEmail: "professor1@ucsb.edu",
+      requester: {
+        fullName: "Student Nine",
+        email: "student9@ucsb.edu",
+      },
+      professor: {
+        fullName: "Professor One",
+        email: "professor1@ucsb.edu",
+      },
+      details: "Accepted request",
+      recommendationType: "Graduate School",
+      status: "ACCEPTED",
+      submissionDate: "2025-02-01T00:00:00",
+      dueDate: "2025-03-01T00:00:00",
+      lastModifiedDate: "2025-02-15T00:00:00",
+      completionDate: null,
+      done: false,
+    },
   ],
 };
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -13,6 +13,7 @@ import * as dateutils from "main/utils/dateutils";
 // format date helper function
 // stryker disable next-line all : dont test this function
 function formatDate(dateString) {
+  if (!dateString) return "";
   return new Date(dateString).toLocaleDateString();
 }
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -9,6 +9,11 @@ import {
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
+// format date helper function
+function formatDate(dateString) {
+  return new Date(dateString).toLocaleDateString();
+}
+
 export default function RecommendationRequestTable({ requests, currentUser }) {
   const navigate = useNavigate();
 
@@ -71,18 +76,31 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     {
       Header: "Submission Date",
       accessor: "submissionDate",
+      // turning into a readable date format mm/dd/yyyy
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Last Modified Date",
       accessor: "lastModifiedDate",
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Completion Date",
       accessor: "completionDate",
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
     {
       Header: "Due Date",
       accessor: "dueDate",
+      Cell: ({ value }) => {
+        return formatDate(value);
+      },
     },
   ];
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
 // format date helper function
+// stryker disable next-line all : dont test this function
 function formatDate(dateString) {
   return new Date(dateString).toLocaleDateString();
 }

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -18,11 +18,14 @@ export default function PendingRequestsPage() {
     error: _error,
     status: _status,
   } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
     [apiEndpoint],
     {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
       method: "GET",
       url: apiEndpoint,
     },
+    // Stryker disable next-line all : it's hard to test GET requests that are still in progress
     [],
   );
 

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -1,11 +1,46 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "main/utils/useBackend";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { useCurrentUser } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
-  // Stryker disable all : placeholder for future implementation
+  const { data: currentUser } = useCurrentUser();
+
+  // make sure professors can see all pending requests for them
+  // and regular users can see all requests they've made
+  const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
+    ? "/api/recommendationrequest/professor/all"
+    : "/api/recommendationrequest/requester/all";
+
+  const {
+    data: requests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    [apiEndpoint],
+    {
+      method: "GET",
+      url: apiEndpoint,
+    },
+    [],
+  );
+
+  // filter requests such that only status = PENDING or ACCEPTED records are shown
+  const pendingRequests = requests?.filter(
+    (request) => request.status === "PENDING" || request.status === "ACCEPTED",
+  ) || [];
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Pending Requests page not yet implemented</h1>
+        <h1>Pending Requests</h1>
+        <div data-testid="RecommendationRequestTable">
+          <RecommendationRequestTable
+            requests={pendingRequests}
+            currentUser={currentUser}
+          />
+        </div>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -27,9 +27,9 @@ export default function PendingRequestsPage() {
   );
 
   // filter requests such that only status = PENDING or ACCEPTED records are shown
-  const pendingRequests = requests?.filter(
-    (request) => request.status === "PENDING" || request.status === "ACCEPTED",
-  ) || [];
+  const pendingRequests = requests.filter(
+    (request) => request.status === "PENDING" || request.status === "ACCEPTED"
+  );
 
   return (
     <BasicLayout>

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -31,7 +31,7 @@ export default function PendingRequestsPage() {
 
   // filter requests such that only status = PENDING or ACCEPTED records are shown
   const pendingRequests = requests.filter(
-    (request) => request.status === "PENDING" || request.status === "ACCEPTED"
+    (request) => request.status === "PENDING" || request.status === "ACCEPTED",
   );
 
   return (

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -95,18 +95,18 @@ describe("UserTable tests", () => {
     expect(deleteButton).toBeInTheDocument();
 
     // expect date to be in the format mm/dd/yyyy
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-submissionDate`)).toHaveTextContent(
-      "1/2/2022",
-    );
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastModifiedDate`)).toHaveTextContent(
-      "6/2/2022",
-    );
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-completionDate`)).toHaveTextContent(
-      "6/2/2022",
-    );
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-dueDate`)).toHaveTextContent(
-      "9/2/2022",
-    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-submissionDate`),
+    ).toHaveTextContent("1/2/2022");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-lastModifiedDate`),
+    ).toHaveTextContent("6/2/2022");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-completionDate`),
+    ).toHaveTextContent("6/2/2022");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-dueDate`),
+    ).toHaveTextContent("9/2/2022");
   });
 
   test("Has the expected column headers and content for adminUser", () => {

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -84,16 +84,16 @@ describe("UserTable tests", () => {
 
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-submissionDate`),
-    ).toHaveTextContent("01/02/2022 12:00");
+    ).toHaveTextContent("1/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-lastModifiedDate`),
-    ).toHaveTextContent("06/02/2022 12:00");
+    ).toHaveTextContent("6/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-completionDate`),
-    ).toHaveTextContent("06/02/2022 12:00");
+    ).toHaveTextContent("6/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-dueDate`),
-    ).toHaveTextContent("09/02/2022 12:00");
+    ).toHaveTextContent("9/2/2022");
 
     const editButton = screen.queryByTestId(
       `${testId}-cell-row-0-col-Edit-button`,
@@ -188,16 +188,16 @@ describe("UserTable tests", () => {
 
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-submissionDate`),
-    ).toHaveTextContent("01/02/2022 12:00");
+    ).toHaveTextContent("1/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-lastModifiedDate`),
-    ).toHaveTextContent("06/02/2022 12:00");
+    ).toHaveTextContent("6/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-completionDate`),
-    ).toHaveTextContent("06/02/2022 12:00");
+    ).toHaveTextContent("6/2/2022");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-dueDate`),
-    ).toHaveTextContent("09/02/2022 12:00");
+    ).toHaveTextContent("9/2/2022");
 
     const deleteButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Delete-button`,

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -93,6 +93,20 @@ describe("UserTable tests", () => {
       `${testId}-cell-row-0-col-Delete-button`,
     );
     expect(deleteButton).toBeInTheDocument();
+
+    // expect date to be in the format mm/dd/yyyy
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-submissionDate`)).toHaveTextContent(
+      "1/2/2022",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastModifiedDate`)).toHaveTextContent(
+      "6/2/2022",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-completionDate`)).toHaveTextContent(
+      "6/2/2022",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-dueDate`)).toHaveTextContent(
+      "9/2/2022",
+    );
   });
 
   test("Has the expected column headers and content for adminUser", () => {

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -71,13 +71,6 @@ describe("PendingRequestsPage tests", () => {
     expect(
       statusCells.every((cell) => cell.textContent !== "DENIED"),
     ).toBeTruthy();
-
-    // make sure the method is get
-    expect(axiosMock.history.get[2].method).toBe("get");
-    // make sure data is being displayed (more than 1 row)
-    const rows = screen.getAllByRole("row");
-    expect(rows.length).toBeGreaterThan(1);
-
   });
 
   test("Renders empty table when no completed requests", async () => {
@@ -107,13 +100,6 @@ describe("PendingRequestsPage tests", () => {
     expect(
       screen.getByTestId("RecommendationRequestTable"),
     ).toBeInTheDocument();
-
-    // make sure the method is get
-    expect(axiosMock.history.get[2].method).toBe("get");
-    
-    // make sure no data is being displayed
-    const rows = screen.getAllByRole("row");
-    expect(rows.length).toBe(3);
   });
 
   test("Renders pending and accepted requests for student", async () => {
@@ -170,13 +156,6 @@ describe("PendingRequestsPage tests", () => {
     expect(
       statusCells.every((cell) => cell.textContent !== "DENIED"),
     ).toBeTruthy();
-
-    // make sure the method is get
-    expect(axiosMock.history.get[2].method).toBe("get");
-
-    // make sure data is being displayed (more than 1 row)
-    const rows = screen.getAllByRole("row");
-    expect(rows.length).toBeGreaterThan(1);
   });
 
   test("Renders empty table when no completed requests for student", async () => {
@@ -206,13 +185,6 @@ describe("PendingRequestsPage tests", () => {
     expect(
       screen.getByTestId("RecommendationRequestTable"),
     ).toBeInTheDocument();
-
-    // make sure the method is get
-    expect(axiosMock.history.get[2].method).toBe("get");
-    
-    // make sure no data is being displayed
-    const rows = screen.getAllByRole("row");
-    expect(rows.length).toBe(3);
   });
 
   test("renders without crashing", async () => {

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -8,10 +8,10 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
-describe("PendingRequestsPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  const queryClient = new QueryClient();
+const axiosMock = new AxiosMockAdapter(axios);
+const queryClient = new QueryClient();
 
+describe("PendingRequestsPage tests", () => {
   beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -1,34 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 describe("PendingRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
+  });
+
+  test("Renders pending requests for professor", async () => {
     axiosMock
       .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
+      .reply(200, apiCurrentUserFixtures.professorUser);
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+    axiosMock
+      .onGet("/api/recommendationrequest/professor/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,7 +36,90 @@ describe("PendingRequestsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
-    await screen.findByText("Pending Requests page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "DENIED"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no pending requests", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.professorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/professor/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+  });
+
+  test("Renders empty table when no pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/requester/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -134,7 +134,6 @@ describe("PendingRequestsPage tests", () => {
         screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
       ).toBeInTheDocument();
     });
-    
 
     const statusCells = screen.getAllByTestId(
       /RecommendationRequestTable-cell-row-.*-col-status/,

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -8,9 +8,6 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
-const axiosMock = new AxiosMockAdapter(axios);
-const queryClient = new QueryClient();
-
 describe("PendingRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
   const queryClient = new QueryClient();


### PR DESCRIPTION
**DOKKU DEPLOYMENT:** https://proj-rec23.dokku-14.cs.ucsb.edu

**To Test:** 
1. Run backend `mvn spring-boot:run`, then frontend `npm start` and open on localhost8080
2. Log into the web application, and toggle Professor mode. Create a new test recommendation request in Swagger, setting status = PENDING.
3. The record should display in the page **localhost:8080/requests/pending**
<img width="1226" alt="Screenshot 2025-05-20 at 6 35 59 PM" src="https://github.com/user-attachments/assets/e4fc9b0c-2073-46c1-a725-1d51024811d2" />

_note: the date is now in mm/dd/yyyy format, this screenshot is just out of date._

Closes #23 