### PR TITLE
remove front end code for toggling role student

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,29 +2,6 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-  // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
-
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
-  // Stryker enable all
-
-  // Stryker disable next-line all : TODO try to make a good test for this
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
-
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
@@ -113,12 +90,6 @@ export default function UsersTable({ users }) {
       "Toggle Professor",
       "success",
       toggleProfessorCallback,
-      "UsersTable",
-    ),
-    ButtonColumn(
-      "Toggle Student",
-      "danger",
-      toggleStudentCallback,
       "UsersTable",
     ),
   ];

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,7 +1,32 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function UsersTable({ users }) {
+  const currentUser = useCurrentUser();
+  const isAdmin = hasRole(currentUser, "ROLE_ADMIN");
+
+  // Stryker disable all : hard to test for query caching
+  function cellToAxiosParamsToggleStudent(cell) {
+    return {
+      url: "/api/admin/users/toggleStudent",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+
+  const toggleStudentMutation = useBackendMutation(
+    cellToAxiosParamsToggleStudent,
+    {},
+    ["/api/admin/users"],
+  );
+
+  const toggleStudentCallback = async (cell) => {
+    toggleStudentMutation.mutate(cell);
+  };
+
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
@@ -92,6 +117,16 @@ export default function UsersTable({ users }) {
       toggleProfessorCallback,
       "UsersTable",
     ),
+    ...(isAdmin
+      ? [
+          ButtonColumn(
+            "Toggle Student",
+            "danger",
+            toggleStudentCallback,
+            "UsersTable",
+          ),
+        ]
+      : []),
   ];
 
   return <OurTable data={users} columns={buttonColumn} testid={"UsersTable"} />;

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,9 +2,35 @@ import { render, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+
+jest.mock("main/utils/currentUser", () => ({
+  useCurrentUser: jest.fn(),
+  hasRole: jest.fn(),
+}));
 
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    useCurrentUser.mockReturnValue({
+      data: { user: { id: 1, email: "admin@example.com" } },
+    });
+
+    hasRole.mockImplementation((_currentUser, role) => role === "ROLE_ADMIN");
+  });
+
+  test("Toggle Student button should appear for admin", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
+
+    // This checks that the Toggle Student button is in the document
+    const toggleStudentButton = screen.getAllByText("Toggle Student")[0];
+    expect(toggleStudentButton).toBeInTheDocument();
+  });
 
   test("renders without crashing for empty table", () => {
     render(


### PR DESCRIPTION
Closes #4 

In this PR, I updated the front end code for toggling role student:
1. All users have student = true as default on first login. Fields professor and admin are false.
- Tested non-admin user with non-ucsb email in image below.
3. Admins (OAuth) can login and toggle the student role for any user.

To view changes:
1. Run localhost and login.
2. Navigate to Admin > Users
<img width="1384" alt="Screenshot 2025-05-20 at 1 08 03 AM" src="https://github.com/user-attachments/assets/a4a3e3c1-e83e-4049-a1e1-4de9be5e2c68" />
Local host: http://localhost:8080/admin/users

Dokku deployment: https://proj-rec-karenlyuan.dokku-14.cs.ucsb.edu

Testing in Dokku: https://proj-rec-karenlyuan.dokku-14.cs.ucsb.edu/admin/users
<img width="1382" alt="Screenshot 2025-05-20 at 1 14 12 AM" src="https://github.com/user-attachments/assets/4d5a7281-ae00-4d06-9e6d-6933246bebd7" />
