### PR TITLE
remove frontend toggling student

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,31 +1,8 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function UsersTable({ users }) {
-  const currentUser = useCurrentUser();
-  const isAdmin = hasRole(currentUser, "ROLE_ADMIN");
-
   // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
-
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
-
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
@@ -101,11 +78,6 @@ export default function UsersTable({ users }) {
       id: "professor",
       accessor: (row, _rowIndex) => String(row.professor), // hack needed for boolean values to show up
     },
-    {
-      Header: "Student",
-      id: "student",
-      accessor: (row, _rowIndex) => String(row.student), // hack needed for boolean values to show up
-    },
   ];
 
   const buttonColumn = [
@@ -117,16 +89,6 @@ export default function UsersTable({ users }) {
       toggleProfessorCallback,
       "UsersTable",
     ),
-    ...(isAdmin
-      ? [
-          ButtonColumn(
-            "Toggle Student",
-            "danger",
-            toggleStudentCallback,
-            "UsersTable",
-          ),
-        ]
-      : []),
   ];
 
   return <OurTable data={users} columns={buttonColumn} testid={"UsersTable"} />;

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,29 +2,6 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-  // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
-
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
-  // Stryker enable all
-
-  // Stryker disable next-line all : TODO try to make a good test for this
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
-
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
@@ -113,12 +90,6 @@ export default function UsersTable({ users }) {
       "Toggle Professor",
       "success",
       toggleProfessorCallback,
-      "UsersTable",
-    ),
-    ButtonColumn(
-      "Toggle Student",
-      "danger",
-      toggleStudentCallback,
       "UsersTable",
     ),
   ];

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,7 +1,32 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function UsersTable({ users }) {
+  const currentUser = useCurrentUser();
+  const isAdmin = hasRole(currentUser, "ROLE_ADMIN");
+
+  // Stryker disable all : hard to test for query caching
+  function cellToAxiosParamsToggleStudent(cell) {
+    return {
+      url: "/api/admin/users/toggleStudent",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+
+  const toggleStudentMutation = useBackendMutation(
+    cellToAxiosParamsToggleStudent,
+    {},
+    ["/api/admin/users"],
+  );
+
+  const toggleStudentCallback = async (cell) => {
+    toggleStudentMutation.mutate(cell);
+  };
+
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
@@ -92,6 +117,16 @@ export default function UsersTable({ users }) {
       toggleProfessorCallback,
       "UsersTable",
     ),
+    ...(isAdmin
+      ? [
+          ButtonColumn(
+            "Toggle Student",
+            "danger",
+            toggleStudentCallback,
+            "UsersTable",
+          ),
+        ]
+      : []),
   ];
 
   return <OurTable data={users} columns={buttonColumn} testid={"UsersTable"} />;

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,35 +2,9 @@ import { render, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { useCurrentUser, hasRole } from "main/utils/currentUser";
-
-jest.mock("main/utils/currentUser", () => ({
-  useCurrentUser: jest.fn(),
-  hasRole: jest.fn(),
-}));
 
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
-
-  beforeEach(() => {
-    useCurrentUser.mockReturnValue({
-      data: { user: { id: 1, email: "admin@example.com" } },
-    });
-
-    hasRole.mockImplementation((_currentUser, role) => role === "ROLE_ADMIN");
-  });
-
-  test("Toggle Student button should appear for admin", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <UsersTable users={usersFixtures.threeUsers} />
-      </QueryClientProvider>,
-    );
-
-    // This checks that the Toggle Student button is in the document
-    const toggleStudentButton = screen.getAllByText("Toggle Student")[0];
-    expect(toggleStudentButton).toBeInTheDocument();
-  });
 
   test("renders without crashing for empty table", () => {
     render(

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -36,7 +36,6 @@ describe("UserTable tests", () => {
       "Email",
       "Admin",
       "Professor",
-      "Student",
     ];
     const expectedFields = [
       "id",
@@ -45,7 +44,6 @@ describe("UserTable tests", () => {
       "email",
       "admin",
       "professor",
-      "student",
     ];
     const testId = "UsersTable";
 
@@ -68,9 +66,6 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-professor`),
     ).toHaveTextContent("false");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-student`),
-    ).toHaveTextContent("false");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "2",
     );
@@ -80,15 +75,9 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-1-col-professor`),
     ).toHaveTextContent("false");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-1-col-student`),
-    ).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
       "3",
     );
-    expect(
-      screen.getByTestId(`${testId}-cell-row-2-col-student`),
-    ).toHaveTextContent("false");
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-professor`),
     ).toHaveTextContent("true");

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,9 +2,35 @@ import { render, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+
+jest.mock("main/utils/currentUser", () => ({
+  useCurrentUser: jest.fn(),
+  hasRole: jest.fn(),
+}));
 
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    useCurrentUser.mockReturnValue({
+      data: { user: { id: 1, email: "admin@example.com" } },
+    });
+
+    hasRole.mockImplementation((_currentUser, role) => role === "ROLE_ADMIN");
+  });
+
+  test("Toggle Student button should appear for admin", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
+
+    // This checks that the Toggle Student button is in the document
+    const toggleStudentButton = screen.getAllByText("Toggle Student")[0];
+    expect(toggleStudentButton).toBeInTheDocument();
+  });
 
   test("renders without crashing for empty table", () => {
     render(


### PR DESCRIPTION
Closes #4 

In this PR, I remove the frontend code that allows admins to toggle the student role on and off for users by removing the column for toggle student.

Dokku deployment: https://proj-rec-karenlyuan.dokku-14.cs.ucsb.edu

Navigate to localhost or dokku deployment > Login > Admin > Users
<img width="1292" alt="Screenshot 2025-05-20 at 10 11 03 PM" src="https://github.com/user-attachments/assets/5544e4df-954e-4833-a43b-102c1aa43693" />
