### PR TITLE
removing toggle for student from backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -127,15 +127,4 @@ public class UsersController extends ApiController {
         return genericMessage("User with id %s has toggled professor status to %s".formatted(id, user.getProfessor()));
     }
 
-    @Operation(summary = "Toggle the student field")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/toggleStudent")
-    public Object toggleStudent( @Parameter(name = "id", description = "Long, id number of user to toggle their student field", example = "1", required = true) @RequestParam Long id){
-        User user = userRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-
-        user.setStudent(!user.getStudent());
-        userRepository.save(user);
-        return genericMessage("User with id %s has toggled student status to %s".formatted(id, user.getStudent()));
-    }
 }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -217,43 +217,43 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("User with id 15 not found", json.get("message"));
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(false).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
+  // @WithMockUser(roles = { "ADMIN", "USER" })
+  // @Test
+  // public void admin_can_toggle_student() throws Exception{
+  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(false).build();
+  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
+  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
+  //            .andExpect(status().isOk()).andReturn();
     
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to true", json.get("message"));
-  }
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student_flip() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(true).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
+  //   verify(userRepository, times(1)).findById(17L);
+  //   Map<String, Object> json = responseToJson(response);
+  //   assertEquals("User with id 17 has toggled student status to true", json.get("message"));
+  // }
+  // @WithMockUser(roles = { "ADMIN", "USER" })
+  // @Test
+  // public void admin_can_toggle_student_flip() throws Exception{
+  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(true).build();
+  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
+  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
+  //            .andExpect(status().isOk()).andReturn();
     
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to false", json.get("message"));
-  }
+  //   verify(userRepository, times(1)).findById(17L);
+  //   Map<String, Object> json = responseToJson(response);
+  //   assertEquals("User with id 17 has toggled student status to false", json.get("message"));
+  // }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_cant_toggle_student_nonexistent() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=15").with(csrf()))
-             .andExpect(status().is(404)).andReturn();
+  // @WithMockUser(roles = { "ADMIN", "USER" })
+  // @Test
+  // public void admin_cant_toggle_student_nonexistent() throws Exception{
+  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).build();
+  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
+  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=15").with(csrf()))
+  //            .andExpect(status().is(404)).andReturn();
     
-    verify(userRepository, times(1)).findById(15L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 15 not found", json.get("message"));
-  }
+  //   verify(userRepository, times(1)).findById(15L);
+  //   Map<String, Object> json = responseToJson(response);
+  //   assertEquals("User with id 15 not found", json.get("message"));
+  // }
 
   @WithMockUser(roles = { "USER" })
   @Test

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -217,43 +217,6 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("User with id 15 not found", json.get("message"));
   }
 
-  // @WithMockUser(roles = { "ADMIN", "USER" })
-  // @Test
-  // public void admin_can_toggle_student() throws Exception{
-  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(false).build();
-  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-  //            .andExpect(status().isOk()).andReturn();
-    
-  //   verify(userRepository, times(1)).findById(17L);
-  //   Map<String, Object> json = responseToJson(response);
-  //   assertEquals("User with id 17 has toggled student status to true", json.get("message"));
-  // }
-  // @WithMockUser(roles = { "ADMIN", "USER" })
-  // @Test
-  // public void admin_can_toggle_student_flip() throws Exception{
-  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(true).build();
-  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-  //            .andExpect(status().isOk()).andReturn();
-    
-  //   verify(userRepository, times(1)).findById(17L);
-  //   Map<String, Object> json = responseToJson(response);
-  //   assertEquals("User with id 17 has toggled student status to false", json.get("message"));
-  // }
-
-  // @WithMockUser(roles = { "ADMIN", "USER" })
-  // @Test
-  // public void admin_cant_toggle_student_nonexistent() throws Exception{
-  //    User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).build();
-  //    when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-  //    MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=15").with(csrf()))
-  //            .andExpect(status().is(404)).andReturn();
-    
-  //   verify(userRepository, times(1)).findById(15L);
-  //   Map<String, Object> json = responseToJson(response);
-  //   assertEquals("User with id 15 not found", json.get("message"));
-  // }
 
   @WithMockUser(roles = { "USER" })
   @Test

--- a/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
@@ -48,6 +48,8 @@ public class HomePageWebIT {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
+        assertThat(page.getByText("Recommendation Request Manager"))
+                .isVisible();
         assertThat(page.getByText("Our webapp allows a simple process for students to submit requests for letters of recommendation to professors, and allows professors to manage their requests."))
                 .isVisible();
     }

--- a/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
@@ -48,7 +48,7 @@ public class HomePageWebIT {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
-        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples."))
+        assertThat(page.getByText("Our webapp allows a simple process for students to submit requests for letters of recommendation to professors, and allows professors to manage their requests."))
                 .isVisible();
     }
 


### PR DESCRIPTION
Closes #7

In this PR, the backend code for toggling Student has been removed.

To verify, visit the UserController file and ensure that there is no code for toggling Student. Also attached below are the before and after on Swagger, where you can see toggle/Student is no longer visible.

Before:
<img width="1434" alt="Screenshot 2025-05-21 at 10 23 31 PM" src="https://github.com/user-attachments/assets/bd3d56b9-4b8c-41d6-ba7c-477a196600a8" />

After:
<img width="1444" alt="Screenshot 2025-05-21 at 10 23 05 PM" src="https://github.com/user-attachments/assets/29bf7afd-636d-4b6b-9581-eb8bf7cfb351" />

