### PR TITLE
The list of hardcoded request types above is added into the Request Type table at startup (check for each one to see if is already there before loading it).

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoader.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoader.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.rec.services;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class RequestTypeDataLoader implements CommandLineRunner {
+
+    @Autowired
+    private RequestTypeRepository requestTypeRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        loadRequestTypes();
+    }
+
+    private void loadRequestTypes() {
+        String[] requestTypes = {
+            "CS Department BS/MS program",
+            "Scholarship or Fellowship",
+            "MS program (other than CS Dept BS/MS)",
+            "PhD program"
+        };
+
+        Arrays.stream(requestTypes).forEach(type -> {
+            Optional<RequestType> existing = requestTypeRepository.findByRequestType(type);
+            if (!existing.isPresent()) {
+                RequestType newType = new RequestType();
+                newType.setRequestType(type);
+                requestTypeRepository.save(newType);
+                
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #21

Created new service file to load request types found in recommendation request fixtures into repository.

![Screenshot 2025-05-22 at 12 40 15 PM](https://github.com/user-attachments/assets/915a4aa8-5573-4a49-8fd5-33d027cc5ef0)

Here is the Swagger screenshot of what request types exist at startup.
