### PR TITLE
The list of hardcoded request types above is added into the Request Type table at startup (check for each one to see if is already there before loading it).

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoader.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoader.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.rec.services;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class RequestTypeDataLoader implements CommandLineRunner {
+
+    @Autowired
+    private RequestTypeRepository requestTypeRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        loadRequestTypes();
+    }
+
+    private void loadRequestTypes() {
+        String[] requestTypes = {
+            "CS Department BS/MS program",
+            "Scholarship or Fellowship",
+            "MS program (other than CS Dept BS/MS)",
+            "PhD program"
+        };
+
+        Arrays.stream(requestTypes).forEach(type -> {
+            Optional<RequestType> existing = requestTypeRepository.findByRequestType(type);
+            if (!existing.isPresent()) {
+                RequestType newType = new RequestType();
+                newType.setRequestType(type);
+                requestTypeRepository.save(newType);
+                
+            }
+        });
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoaderTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/RequestTypeDataLoaderTests.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.rec.services;
+
+import edu.ucsb.cs156.rec.entities.RequestType;
+import edu.ucsb.cs156.rec.repositories.RequestTypeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.CommandLineRunner;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestTypeDataLoaderTests {
+
+    private RequestTypeRepository requestTypeRepository;
+    private RequestTypeDataLoader requestTypeDataLoader;
+
+    @BeforeEach
+    void setup() {
+        requestTypeRepository = mock(RequestTypeRepository.class);
+        requestTypeDataLoader = new RequestTypeDataLoader();
+        try {
+            var field = RequestTypeDataLoader.class.getDeclaredField("requestTypeRepository");
+            field.setAccessible(true);
+            field.set(requestTypeDataLoader, requestTypeRepository);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void test_loadRequestTypes_inserts_new_entries_if_not_exists() throws Exception {
+        when(requestTypeRepository.findByRequestType(anyString())).thenReturn(Optional.empty());
+
+        requestTypeDataLoader.run();
+
+        ArgumentCaptor<RequestType> captor = ArgumentCaptor.forClass(RequestType.class);
+        verify(requestTypeRepository, times(4)).save(captor.capture());
+
+        var savedTypes = captor.getAllValues();
+        assertEquals(4, savedTypes.size());
+        assertTrue(savedTypes.stream().anyMatch(rt -> rt.getRequestType().equals("CS Department BS/MS program")));
+        assertTrue(savedTypes.stream().anyMatch(rt -> rt.getRequestType().equals("Scholarship or Fellowship")));
+        assertTrue(savedTypes.stream().anyMatch(rt -> rt.getRequestType().equals("MS program (other than CS Dept BS/MS)")));
+        assertTrue(savedTypes.stream().anyMatch(rt -> rt.getRequestType().equals("PhD program")));
+    }
+
+    @Test
+    void test_loadRequestTypes_does_not_insert_if_exists() throws Exception {
+        when(requestTypeRepository.findByRequestType(anyString())).thenReturn(Optional.of(new RequestType()));
+
+        requestTypeDataLoader.run();
+
+        verify(requestTypeRepository, never()).save(any());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
@@ -48,7 +48,9 @@ public class HomePageWebIT {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
-        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples."))
+        assertThat(page.getByText("Recommendation Request Manager"))
+                .isVisible();
+        assertThat(page.getByText("Our webapp allows a simple process for students to submit requests for letters of recommendation to professors, and allows professors to manage their requests."))
                 .isVisible();
     }
 


### PR DESCRIPTION
Closes #21

Created new service file to load request types found in recommendation request fixtures into repository.

![Screenshot 2025-05-22 at 12 40 15 PM](https://github.com/user-attachments/assets/541a6213-fcd4-40a2-a1c4-6b663dbab798)

Here is the Swagger screenshot of what request types exist at startup.

Deployed at: http://sm-hardcode.dokku-14.cs.ucsb.edu