### PR TITLE
explicitly convert to bigint

### DIFF
--- a/src/main/resources/db/migration/changes/RecommendationRequest-002.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest-002.json
@@ -1,31 +1,37 @@
 {
-    "databaseChangeLog": [
-      {
-        "changeSet": {
-          "id": "RecommendationRequest-002",
-          "author": "ryanchoi07",
-          "changes": [
-            {
-              "renameColumn": {
-                "tableName": "RECOMMENDATIONREQUEST",
-                "oldColumnName": "RECOMMENDATION_TYPE",
-                "newColumnName": "RECOMMENDATION_TYPE_ID",
-                "columnDataType": "BIGINT"
-              }
-            },
-            {
-              "addForeignKeyConstraint": {
-                "baseColumnNames": "RECOMMENDATION_TYPE_ID",
-                "baseTableName": "RECOMMENDATIONREQUEST",
-                "constraintName": "RECOMMENDATIONREQUEST_RECOMMENDATION_TYPE_ID_FK",
-                "referencedColumnNames": "ID",
-                "referencedTableName": "REQUESTTYPE",
-                "onDelete": "RESTRICT",
-                "onUpdate": "RESTRICT"
-              }
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "RecommendationRequest-002",
+        "author": "ryanchoi07",
+        "changes": [
+          {
+            "renameColumn": {
+              "tableName": "RECOMMENDATIONREQUEST",
+              "oldColumnName": "RECOMMENDATION_TYPE",
+              "newColumnName": "RECOMMENDATION_TYPE_ID"
             }
-          ]
-        }
+          },
+          {
+            "modifyDataType": {
+              "tableName": "RECOMMENDATIONREQUEST",
+              "columnName": "RECOMMENDATION_TYPE_ID",
+              "newDataType": "BIGINT"
+            }
+          },
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "RECOMMENDATION_TYPE_ID",
+              "baseTableName": "RECOMMENDATIONREQUEST",
+              "constraintName": "RECOMMENDATIONREQUEST_RECOMMENDATION_TYPE_ID_FK",
+              "referencedColumnNames": "ID",
+              "referencedTableName": "REQUESTTYPE",
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT"
+            }
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
+}


### PR DESCRIPTION
BUG FIX
Deployed at: https://rec-dev-ryanchoi07.dokku-14.cs.ucsb.edu/

Fixes previous db migration file that caused issues with dokku deployment, previous error was renameColumn did not actually modify type from VARCHAR(255) to BIGINT, and so there were type mismatches: RecommendationTypeId (VARCHAR(255)) to RequestType ID (BIGINT).

This modification was made in awareness that DB migration files should GENERALLY not be modified once committed to main, but after discussing with TAs during office hours, this fix was seen as optimal. 

Ways to test original functionality (references #25)
1. Go to dokku site
2. Create new Request Type on Swagger
3. Use ID of newly created Request Type to create new RecommendationType, should execute successfully.
4. For invalid input, use ID of nonexistent Request Type to create new RecommendationType, should throw IllegalArgumentException